### PR TITLE
Support for `nint` and `nuint`

### DIFF
--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -11,10 +11,14 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.x
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
     - name: Build and test with dotnet
       working-directory: src
       run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You may have come across while working in .NET where you would like to perform n
 
 This library fills that gap by providing most standard numeric operations for the following built-in numeric types and their nullable equivalents with the ability to add support for other numeric types.
 
-`sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, and `BigInteger`
+`sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, `nint`, `nuint`, and `BigInteger`
 
 ## Genumerics Demo
 Below is a demo of some basic uses of Genumerics in the form of unit tests.

--- a/src/Genumerics.Tests/Genumerics.Tests.csproj
+++ b/src/Genumerics.Tests/Genumerics.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;netcoreapp2.0;net45</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Genumerics.Tests/NumberTests.cs
+++ b/src/Genumerics.Tests/NumberTests.cs
@@ -179,7 +179,7 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(decimal.MaxValue);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(int.MaxValue));
             yield return CreateTestCase<nint>(IntPtr.Size == 4 ? (nint)int.MaxValue : unchecked((nint)long.MaxValue));
-            yield return CreateTestCase<nuint>(UIntPtr.Size == 4 ? (nuint)int.MaxValue : unchecked((nuint)ulong.MaxValue));
+            yield return CreateTestCase<nuint>(UIntPtr.Size == 4 ? (nuint)uint.MaxValue : unchecked((nuint)ulong.MaxValue));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)int.MaxValue);
         }
 
@@ -1642,6 +1642,7 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(-2));
             yield return CreateTestCase<nint>((nint)3, (nint)3);
             yield return CreateTestCase<nint>((nint)2, -(nint)2);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(-2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday);
@@ -1855,10 +1856,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(-1, new BigInteger(3), new BigInteger(6));
             yield return CreateTestCase<BigInteger>(0, new BigInteger(3), new BigInteger(3));
             yield return CreateTestCase<nint>(1, (nint)3, (nint)2);
-            yield return CreateTestCase<nint>(-3, (nint)3, (nint)6);
+            yield return CreateTestCase<nint>(-1, (nint)3, (nint)6);
             yield return CreateTestCase<nint>(0, (nint)3, (nint)3);
             yield return CreateTestCase<nuint>(1, (nuint)3, (nuint)2);
-            yield return CreateTestCase<nuint>(-3, (nuint)3, (nuint)6);
+            yield return CreateTestCase<nuint>(-1, (nuint)3, (nuint)6);
             yield return CreateTestCase<nuint>(0, (nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(1, new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<IntWrapper>(-1, new IntWrapper(3), new IntWrapper(6));
@@ -2163,11 +2164,13 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(new BigInteger(-128), " -128 ", NumberStyles.Integer);
             yield return CreateTestCase<BigInteger>(new BigInteger(uint.MaxValue), " 00000000FFFFFFFF ", NumberStyles.HexNumber);
             yield return CreateTestCase<BigInteger>(new BigInteger(-1), " FFFFFFFF ", NumberStyles.HexNumber);
+            string nativeIntAllBits = IntPtr.Size == 4 ? " FFFFFFFF " : " FFFFFFFFFFFFFFFF ";
+            nuint nativeUIntMax = UIntPtr.Size == 4 ? uint.MaxValue : unchecked((nuint)ulong.MaxValue);
             yield return CreateTestCase<nint>((nint)8, "8", null);
             yield return CreateTestCase<nint>(-(nint)128, " -128 ", NumberStyles.Integer);
-            yield return CreateTestCase<nint>(-(nint)1, " FF ", NumberStyles.HexNumber);
+            yield return CreateTestCase<nint>(-(nint)1, nativeIntAllBits, NumberStyles.HexNumber);
             yield return CreateTestCase<nuint>((nuint)8, "8", null);
-            yield return CreateTestCase<nuint>((nuint)255, " FF ", NumberStyles.HexNumber);
+            yield return CreateTestCase<nuint>(nativeUIntMax, nativeIntAllBits, NumberStyles.HexNumber);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(8), "8", null);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-128), " -128 ", NumberStyles.Integer);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-1), " FFFFFFFF ", NumberStyles.HexNumber);

--- a/src/Genumerics.Tests/NumberTests.cs
+++ b/src/Genumerics.Tests/NumberTests.cs
@@ -178,6 +178,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(double.MaxValue);
             yield return CreateTestCase<decimal>(decimal.MaxValue);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(int.MaxValue));
+            yield return CreateTestCase<nint>(IntPtr.Size == 4 ? (nint)int.MaxValue : unchecked((nint)long.MaxValue));
+            yield return CreateTestCase<nuint>(UIntPtr.Size == 4 ? (nuint)int.MaxValue : unchecked((nuint)ulong.MaxValue));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)int.MaxValue);
         }
 
@@ -220,6 +222,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(double.MinValue);
             yield return CreateTestCase<decimal>(decimal.MinValue);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(int.MinValue));
+            yield return CreateTestCase<nint>(IntPtr.Size == 4 ? (nint)int.MinValue : unchecked((nint)long.MinValue));
+            yield return CreateTestCase<nuint>(UIntPtr.Size == 4 ? (nuint)uint.MinValue : unchecked((nuint)ulong.MinValue));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)int.MinValue);
         }
 
@@ -1419,6 +1423,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ulong>(true, 18446744073709551614UL);
             yield return CreateTestCase<BigInteger>(false, new BigInteger(3));
             yield return CreateTestCase<BigInteger>(true, new BigInteger(2));
+            yield return CreateTestCase<nint>(false, (nint)3);
+            yield return CreateTestCase<nint>(true, (nint)2);
+            yield return CreateTestCase<nuint>(false, (nuint)3);
+            yield return CreateTestCase<nuint>(true, (nuint)2);
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(false, DayOfWeek.Wednesday);
@@ -1467,6 +1475,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ulong>(false, 18446744073709551614UL);
             yield return CreateTestCase<BigInteger>(true, new BigInteger(3));
             yield return CreateTestCase<BigInteger>(false, new BigInteger(2));
+            yield return CreateTestCase<nint>(true, (nint)3);
+            yield return CreateTestCase<nint>(false, (nint)2);
+            yield return CreateTestCase<nuint>(true, (nuint)3);
+            yield return CreateTestCase<nuint>(false, (nuint)2);
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(true, DayOfWeek.Wednesday);
@@ -1515,6 +1527,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ulong>(true, 2UL);
             yield return CreateTestCase<BigInteger>(false, new BigInteger(3));
             yield return CreateTestCase<BigInteger>(true, new BigInteger(2));
+            yield return CreateTestCase<nint>(false, (nint)3);
+            yield return CreateTestCase<nint>(true, (nint)2);
+            yield return CreateTestCase<nuint>(false, (nuint)3);
+            yield return CreateTestCase<nuint>(true, (nuint)2);
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(false, DayOfWeek.Wednesday);
@@ -1577,6 +1593,11 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(1, new BigInteger(3));
             yield return CreateTestCase<BigInteger>(0, new BigInteger(0));
             yield return CreateTestCase<BigInteger>(-1, new BigInteger(-2));
+            yield return CreateTestCase<nint>(1, (nint)3);
+            yield return CreateTestCase<nint>(0, (nint)0);
+            yield return CreateTestCase<nint>(-1, -(nint)2);
+            yield return CreateTestCase<nuint>(1, (nuint)3);
+            yield return CreateTestCase<nuint>(0, (nuint)0);
             yield return CreateTestCase<IntWrapper>(1, new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(0, new IntWrapper(0));
             yield return CreateTestCase<IntWrapper>(-1, new IntWrapper(-2));
@@ -1619,6 +1640,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(2M, -2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3));
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(-2));
+            yield return CreateTestCase<nint>((nint)3, (nint)3);
+            yield return CreateTestCase<nint>((nint)2, -(nint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(-2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday);
@@ -1654,6 +1677,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(3M, 3.9M);
             yield return CreateTestCase<decimal>(-3M, -2.9M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3));
+            yield return CreateTestCase<nint>((nint)3, (nint)3);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday);
         }
@@ -1687,6 +1712,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(4M, 3.9M);
             yield return CreateTestCase<decimal>(-2M, -2.9M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3));
+            yield return CreateTestCase<nint>((nint)3, (nint)3);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday);
         }
@@ -1720,6 +1747,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(3M, 3.9M);
             yield return CreateTestCase<decimal>(-2M, -2.9M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3));
+            yield return CreateTestCase<nint>((nint)3, (nint)3);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday);
         }
@@ -1759,6 +1788,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(-2M, -2.5M, 0, MidpointRounding.ToEven);
             yield return CreateTestCase<decimal>(-3M, -2.5M, 0, MidpointRounding.AwayFromZero);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3), 0, MidpointRounding.ToEven);
+            yield return CreateTestCase<nint>((nint)3, (nint)3, 0, MidpointRounding.ToEven);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3, 0, MidpointRounding.ToEven);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3), 0, MidpointRounding.ToEven);
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday, 0, MidpointRounding.ToEven);
         }
@@ -1823,6 +1854,12 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(1, new BigInteger(3), new BigInteger(2));
             yield return CreateTestCase<BigInteger>(-1, new BigInteger(3), new BigInteger(6));
             yield return CreateTestCase<BigInteger>(0, new BigInteger(3), new BigInteger(3));
+            yield return CreateTestCase<nint>(1, (nint)3, (nint)2);
+            yield return CreateTestCase<nint>(-3, (nint)3, (nint)6);
+            yield return CreateTestCase<nint>(0, (nint)3, (nint)3);
+            yield return CreateTestCase<nuint>(1, (nuint)3, (nuint)2);
+            yield return CreateTestCase<nuint>(-3, (nuint)3, (nuint)6);
+            yield return CreateTestCase<nuint>(0, (nuint)3, (nuint)3);
             yield return CreateTestCase<IntWrapper>(1, new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<IntWrapper>(-1, new IntWrapper(3), new IntWrapper(6));
             yield return CreateTestCase<IntWrapper>(0, new IntWrapper(3), new IntWrapper(3));
@@ -2018,6 +2055,11 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>("-3", new BigInteger(-3), null);
             yield return CreateTestCase<BigInteger>("2", new BigInteger(2), "D");
             yield return CreateTestCase<BigInteger>("0F", new BigInteger(15), "X");
+            yield return CreateTestCase<nint>("-3", -(nint)3, null);
+            yield return CreateTestCase<nint>("2", (nint)2, "D");
+            yield return CreateTestCase<nint>("F", (nint)15, "X");
+            yield return CreateTestCase<nuint>("2", (nuint)2, "D");
+            yield return CreateTestCase<nuint>("F", (nuint)15, "X");
             yield return CreateTestCase<IntWrapper>("-3", new IntWrapper(-3), null);
             yield return CreateTestCase<IntWrapper>("2", new IntWrapper(2), "D");
             yield return CreateTestCase<IntWrapper>("F", new IntWrapper(15), "X");
@@ -2121,6 +2163,11 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(new BigInteger(-128), " -128 ", NumberStyles.Integer);
             yield return CreateTestCase<BigInteger>(new BigInteger(uint.MaxValue), " 00000000FFFFFFFF ", NumberStyles.HexNumber);
             yield return CreateTestCase<BigInteger>(new BigInteger(-1), " FFFFFFFF ", NumberStyles.HexNumber);
+            yield return CreateTestCase<nint>((nint)8, "8", null);
+            yield return CreateTestCase<nint>(-(nint)128, " -128 ", NumberStyles.Integer);
+            yield return CreateTestCase<nint>(-(nint)1, " FF ", NumberStyles.HexNumber);
+            yield return CreateTestCase<nuint>((nuint)8, "8", null);
+            yield return CreateTestCase<nuint>((nuint)255, " FF ", NumberStyles.HexNumber);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(8), "8", null);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-128), " -128 ", NumberStyles.Integer);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-1), " FFFFFFFF ", NumberStyles.HexNumber);
@@ -2191,6 +2238,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<uint>(new object?[] { int.MinValue.ToString(), null, typeof(OverflowException) });
             yield return CreateTestCase<long>(new object?[] { ulong.MaxValue.ToString(), null, typeof(OverflowException) });
             yield return CreateTestCase<ulong>(new object?[] { long.MinValue.ToString(), null, typeof(OverflowException) });
+            yield return CreateTestCase<nint>(new object?[] { ulong.MaxValue.ToString(), null, typeof(OverflowException) });
+            yield return CreateTestCase<nuint>(new object?[] { long.MinValue.ToString(), null, typeof(OverflowException) });
             yield return CreateTestCase<IntWrapper>(new object?[] { uint.MaxValue.ToString(), null, typeof(OverflowException) });
             yield return CreateTestCase<DayOfWeek>(new object?[] { uint.MaxValue.ToString(), null, typeof(OverflowException) });
             yield return CreateTestCase<sbyte>(new object?[] { "a", null, typeof(FormatException) });
@@ -2204,6 +2253,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<float>(new object?[] { "a", null, typeof(FormatException) });
             yield return CreateTestCase<double>(new object?[] { "a", null, typeof(FormatException) });
             yield return CreateTestCase<BigInteger>(new object?[] { "a", null, typeof(FormatException) });
+            yield return CreateTestCase<nint>(new object?[] { "a", null, typeof(FormatException) });
+            yield return CreateTestCase<nuint>(new object?[] { "a", null, typeof(FormatException) });
             yield return CreateTestCase<IntWrapper>(new object?[] { "a", null, typeof(FormatException) });
             yield return CreateTestCase<DayOfWeek>(new object?[] { "a", null, typeof(ArgumentException) });
         }
@@ -2261,6 +2312,12 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3), new BigInteger(2), new BigInteger(5));
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(1), new BigInteger(2), new BigInteger(5));
             yield return CreateTestCase<BigInteger>(new BigInteger(5), new BigInteger(8), new BigInteger(2), new BigInteger(5));
+            yield return CreateTestCase<nint>((nint)3, (nint)3, (nint)2, (nint)5);
+            yield return CreateTestCase<nint>((nint)2, (nint)1, (nint)2, (nint)5);
+            yield return CreateTestCase<nint>((nint)5, (nint)8, (nint)2, (nint)5);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3, (nuint)2, (nuint)5);
+            yield return CreateTestCase<nuint>((nuint)2, (nuint)1, (nuint)2, (nuint)5);
+            yield return CreateTestCase<nuint>((nuint)5, (nuint)8, (nuint)2, (nuint)5);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3), new IntWrapper(2), new IntWrapper(5));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(1), new IntWrapper(2), new IntWrapper(5));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(5), new IntWrapper(8), new IntWrapper(2), new IntWrapper(5));
@@ -2311,6 +2368,12 @@ namespace Genumerics.Tests
             yield return CreateTestCase<BigInteger>(null, null, new BigInteger(2), new BigInteger(5));
             yield return CreateTestCase<BigInteger>(null, new BigInteger(1), null, new BigInteger(5));
             yield return CreateTestCase<BigInteger>(null, new BigInteger(8), new BigInteger(2), null);
+            yield return CreateTestCase<nint>(null, null, (nint)2, (nint)5);
+            yield return CreateTestCase<nint>(null, (nint)3, null, (nint)5);
+            yield return CreateTestCase<nint>(null, (nint)3, (nint)2, null);
+            yield return CreateTestCase<nuint>(null, null, (nuint)2, (nuint)5);
+            yield return CreateTestCase<nuint>(null, (nuint)1, null, (nuint)5);
+            yield return CreateTestCase<nuint>(null, (nuint)8, (nuint)2, null);
             yield return CreateTestCase<IntWrapper>(null, null, new IntWrapper(2), new IntWrapper(5));
             yield return CreateTestCase<IntWrapper>(null, new IntWrapper(1), null, new IntWrapper(5));
             yield return CreateTestCase<IntWrapper>(null, new IntWrapper(8), new IntWrapper(2), null);
@@ -2333,6 +2396,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(new object[] { 3D, 8D, 5D });
             yield return CreateTestCase<decimal>(new object[] { 3M, 8M, 5M });
             yield return CreateTestCase<BigInteger>(new object[] { new BigInteger(3), new BigInteger(8), new BigInteger(5) });
+            yield return CreateTestCase<nint>(new object[] { (nint)3, (nint)8, (nint)5 });
+            yield return CreateTestCase<nuint>(new object[] { (nuint)3, (nuint)8, (nuint)5 });
             yield return CreateTestCase<IntWrapper>(new object[] { new IntWrapper(3), new IntWrapper(8), new IntWrapper(5) });
             yield return CreateTestCase<DayOfWeek>(new object[] { DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Friday });
         }
@@ -2489,6 +2554,14 @@ namespace Genumerics.Tests
             if (types.HasAnyFlags(TestTypes.BigInteger))
             {
                 yield return CreateTestCase<BigInteger>(nullResult, args);
+            }
+            if (types.HasAllFlags(TestTypes.NativeInt))
+            {
+                yield return CreateTestCase<nint>(nullResult, args);
+            }
+            if (types.HasAllFlags(TestTypes.NativeUInt))
+            {
+                yield return CreateTestCase<nuint>(nullResult, args);
             }
             if (types.HasAnyFlags(TestTypes.IntWrapper))
             {

--- a/src/Genumerics.Tests/NumberTests.cs
+++ b/src/Genumerics.Tests/NumberTests.cs
@@ -74,6 +74,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(0D);
             yield return CreateTestCase<decimal>(0M);
             yield return CreateTestCase<BigInteger>(BigInteger.Zero);
+            yield return CreateTestCase<nint>((nint)0);
+            yield return CreateTestCase<nuint>((nuint)0);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(0));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Sunday);
         }
@@ -102,6 +104,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(1D);
             yield return CreateTestCase<decimal>(1M);
             yield return CreateTestCase<BigInteger>(BigInteger.One);
+            yield return CreateTestCase<nint>((nint)1);
+            yield return CreateTestCase<nuint>((nuint)1);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(1));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Monday);
         }
@@ -126,6 +130,7 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(-1D);
             yield return CreateTestCase<decimal>(-1M);
             yield return CreateTestCase<BigInteger>(BigInteger.MinusOne);
+            yield return CreateTestCase<nint>((nint)(-1));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-1));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)(-1));
         }
@@ -146,6 +151,7 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ushort>();
             yield return CreateTestCase<uint>();
             yield return CreateTestCase<ulong>();
+            yield return CreateTestCase<nuint>();
         }
 
         [TestCaseSource(nameof(MaxValueCases))]
@@ -260,6 +266,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<float>(TypeCode.Single);
             yield return CreateTestCase<double>(TypeCode.Double);
             yield return CreateTestCase<decimal>(TypeCode.Decimal);
+            yield return CreateTestCase<nint>(TypeCode.Object);
+            yield return CreateTestCase<nuint>(TypeCode.Object);
             yield return CreateTestCase<BigInteger>(TypeCode.Object);
             yield return CreateTestCase<IntWrapper>(TypeCode.Int32);
             yield return CreateTestCase<DayOfWeek>(TypeCode.Int32);
@@ -311,6 +319,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(false, decimal.MaxValue, decimal.MinValue);
             yield return CreateTestCase<BigInteger>(true, BigInteger.One, BigInteger.One);
             yield return CreateTestCase<BigInteger>(false, BigInteger.One, BigInteger.Zero);
+            yield return CreateTestCase<nint>(true, (nint)1, (nint)1);
+            yield return CreateTestCase<nint>(false, (nint)1, (nint)0);
+            yield return CreateTestCase<nuint>(true, (nuint)1, (nuint)1);
+            yield return CreateTestCase<nuint>(false, (nuint)1, (nuint)0);
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MaxValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MaxValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<DayOfWeek>(true, DayOfWeek.Monday, DayOfWeek.Monday);
@@ -365,6 +377,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(true, decimal.MaxValue, decimal.MinValue);
             yield return CreateTestCase<BigInteger>(false, BigInteger.One, BigInteger.One);
             yield return CreateTestCase<BigInteger>(true, BigInteger.One, BigInteger.Zero);
+            yield return CreateTestCase<nint>(false, (nint)1, (nint)1);
+            yield return CreateTestCase<nint>(true, (nint)1, (nint)0);
+            yield return CreateTestCase<nuint>(false, (nuint)1, (nuint)1);
+            yield return CreateTestCase<nuint>(true, (nuint)1, (nuint)0);
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MaxValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MaxValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<DayOfWeek>(false, DayOfWeek.Monday, DayOfWeek.Monday);
@@ -419,6 +435,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(true, decimal.MinValue, decimal.MaxValue);
             yield return CreateTestCase<BigInteger>(false, BigInteger.Zero, BigInteger.Zero);
             yield return CreateTestCase<BigInteger>(true, BigInteger.Zero, BigInteger.One);
+            yield return CreateTestCase<nint>(false, (nint)0, (nint)0);
+            yield return CreateTestCase<nint>(true, (nint)0, (nint)1);
+            yield return CreateTestCase<nuint>(false, (nuint)0, (nuint)0);
+            yield return CreateTestCase<nuint>(true, (nuint)0, (nuint)1);
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MinValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MinValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<DayOfWeek>(false, DayOfWeek.Sunday, DayOfWeek.Sunday);
@@ -473,6 +493,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(false, decimal.MaxValue, decimal.MinValue);
             yield return CreateTestCase<BigInteger>(true, BigInteger.One, BigInteger.One);
             yield return CreateTestCase<BigInteger>(false, BigInteger.One, BigInteger.Zero);
+            yield return CreateTestCase<nint>(true, (nint)1, (nint)1);
+            yield return CreateTestCase<nint>(false, (nint)1, (nint)0);
+            yield return CreateTestCase<nuint>(true, (nuint)1, (nuint)1);
+            yield return CreateTestCase<nuint>(false, (nuint)1, (nuint)0);
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MaxValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MaxValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<DayOfWeek>(true, DayOfWeek.Monday, DayOfWeek.Monday);
@@ -527,6 +551,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(true, decimal.MaxValue, decimal.MinValue);
             yield return CreateTestCase<BigInteger>(false, BigInteger.One, BigInteger.One);
             yield return CreateTestCase<BigInteger>(true, BigInteger.One, BigInteger.Zero);
+            yield return CreateTestCase<nint>(false, (nint)1, (nint)1);
+            yield return CreateTestCase<nint>(true, (nint)1, (nint)0);
+            yield return CreateTestCase<nuint>(false, (nuint)1, (nuint)1);
+            yield return CreateTestCase<nuint>(true, (nuint)1, (nuint)0);
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MaxValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MaxValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<DayOfWeek>(false, DayOfWeek.Monday, DayOfWeek.Monday);
@@ -581,6 +609,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(false, decimal.MinValue, decimal.MaxValue);
             yield return CreateTestCase<BigInteger>(true, BigInteger.Zero, BigInteger.Zero);
             yield return CreateTestCase<BigInteger>(false, BigInteger.Zero, BigInteger.One);
+            yield return CreateTestCase<nint>(true, (nint)0, (nint)0);
+            yield return CreateTestCase<nint>(false, (nint)0, (nint)1);
+            yield return CreateTestCase<nuint>(true, (nuint)0, (nuint)0);
+            yield return CreateTestCase<nuint>(false, (nuint)0, (nuint)1);
             yield return CreateTestCase<IntWrapper>(true, new IntWrapper(int.MinValue), new IntWrapper(int.MinValue));
             yield return CreateTestCase<IntWrapper>(false, new IntWrapper(int.MinValue), new IntWrapper(int.MaxValue));
             yield return CreateTestCase<DayOfWeek>(true, DayOfWeek.Sunday, DayOfWeek.Sunday);
@@ -623,6 +655,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(5D, 3D, 2D);
             yield return CreateTestCase<decimal>(5M, 3M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(5), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)5, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)5, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(5), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Friday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -663,6 +697,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(1D, 3D, 2D);
             yield return CreateTestCase<decimal>(1M, 3M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(1), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)1, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)1, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(1), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -703,6 +739,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(6D, 3D, 2D);
             yield return CreateTestCase<decimal>(6M, 3M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(6), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)6, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)6, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(6), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -743,6 +781,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(3D, 6D, 2D);
             yield return CreateTestCase<decimal>(3M, 6M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(6), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)3, (nint)6, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)6, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(6), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Tuesday);
         }
@@ -783,6 +823,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(2D, 5D, 3D);
             yield return CreateTestCase<decimal>(2M, 5M, 3M);
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(5), new BigInteger(3));
+            yield return CreateTestCase<nint>((nint)2, (nint)5, (nint)3);
+            yield return CreateTestCase<nuint>((nuint)2, (nuint)5, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(5), new IntWrapper(3));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Tuesday, DayOfWeek.Friday, DayOfWeek.Wednesday);
         }
@@ -824,6 +866,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(2.5, 5D, 2D, 1D);
             yield return CreateTestCase<decimal>(2.5M, 5M, 2M, 1M);
             yield return CreateTestCase<BigInteger>(new BigInteger(1), new BigInteger(5), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)1, (nint)5, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)1, (nuint)5, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(1), new IntWrapper(5), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Monday, DayOfWeek.Friday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -868,6 +912,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<decimal>(2M, -2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(-3), new BigInteger(3));
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(-2));
+            yield return CreateTestCase<nint>((nint)2, -(nint)2);
+            yield return CreateTestCase<nint>(-(nint)3, (nint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-3), new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(-2));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)(-3), DayOfWeek.Wednesday);
@@ -902,6 +948,7 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ushort>(new object[] { (ushort)3 });
             yield return CreateTestCase<uint>(new object[] { (uint)3 });
             yield return CreateTestCase<ulong>(new object[] { (ulong)3 });
+            yield return CreateTestCase<nuint>(new object[] { (nuint)3 });
         }
 
         [TestCaseSource(nameof(MaxCases))]
@@ -928,6 +975,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(3D, 3D, 2D);
             yield return CreateTestCase<decimal>(3M, 3M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)3, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -958,6 +1007,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<double>(2D, 3D, 2D);
             yield return CreateTestCase<decimal>(2M, 3M, 2M);
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(3), new BigInteger(2));
+            yield return CreateTestCase<nint>((nint)2, (nint)3, (nint)2);
+            yield return CreateTestCase<nuint>((nuint)2, (nuint)3, (nuint)2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(3), new IntWrapper(2));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Tuesday);
         }
@@ -995,6 +1046,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<long>(2L, 3L, 6L);
             yield return CreateTestCase<ulong>(2UL, 3UL, 6UL);
             yield return CreateTestCase<BigInteger>(new BigInteger(2), new BigInteger(3), new BigInteger(6));
+            yield return CreateTestCase<nint>((nint)2, (nint)3, (nint)6);
+            yield return CreateTestCase<nuint>((nuint)2, (nuint)3, (nuint)6);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(2), new IntWrapper(3), new IntWrapper(6));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Saturday);
         }
@@ -1052,6 +1105,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<long>(7L, 3L, 5L);
             yield return CreateTestCase<ulong>(7UL, 3UL, 5UL);
             yield return CreateTestCase<BigInteger>(new BigInteger(7), new BigInteger(3), new BigInteger(5));
+            yield return CreateTestCase<nint>((nint)7, (nint)3, (nint)5);
+            yield return CreateTestCase<nuint>((nuint)7, (nuint)3, (nuint)5);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(7), new IntWrapper(3), new IntWrapper(5));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)7, DayOfWeek.Wednesday, DayOfWeek.Friday);
         }
@@ -1109,6 +1164,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<long>(6L, 3L, 5L);
             yield return CreateTestCase<ulong>(6UL, 3UL, 5UL);
             yield return CreateTestCase<BigInteger>(new BigInteger(6), new BigInteger(3), new BigInteger(5));
+            yield return CreateTestCase<nint>((nint)6, (nint)3, (nint)5);
+            yield return CreateTestCase<nuint>((nuint)6, (nuint)3, (nuint)5);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(6), new IntWrapper(3), new IntWrapper(5));
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Friday);
         }
@@ -1175,6 +1232,10 @@ namespace Genumerics.Tests
             yield return CreateTestCase<ulong>(1UL, 18446744073709551614UL);
             yield return CreateTestCase<BigInteger>(new BigInteger(-4), new BigInteger(3));
             yield return CreateTestCase<BigInteger>(new BigInteger(1), new BigInteger(-2));
+            yield return CreateTestCase<nint>(-(nint)4, (nint)3);
+            yield return CreateTestCase<nint>((nint)1, -(nint)2);
+            nuint native3complement = IntPtr.Size == 4 ? 4294967292U : unchecked((nuint)18446744073709551612UL);
+            yield return CreateTestCase<nuint>(native3complement, (nuint)3);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(-4), new IntWrapper(3));
             yield return CreateTestCase<IntWrapper>(new IntWrapper(1), new IntWrapper(-2));
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)(-4), DayOfWeek.Wednesday);
@@ -1234,6 +1295,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<long>(12L, 3L, 2);
             yield return CreateTestCase<ulong>(12UL, 3UL, 2);
             yield return CreateTestCase<BigInteger>(new BigInteger(12), new BigInteger(3), 2);
+            yield return CreateTestCase<nint>((nint)12, (nint)3, 2);
+            yield return CreateTestCase<nuint>((nuint)12, (nuint)3, 2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(12), new IntWrapper(3), 2);
             yield return CreateTestCase<DayOfWeek>((DayOfWeek)12, DayOfWeek.Wednesday, 2);
         }
@@ -1291,6 +1354,8 @@ namespace Genumerics.Tests
             yield return CreateTestCase<long>(3L, 13L, 2);
             yield return CreateTestCase<ulong>(3UL, 13UL, 2);
             yield return CreateTestCase<BigInteger>(new BigInteger(3), new BigInteger(13), 2);
+            yield return CreateTestCase<nint>((nint)3, (nint)13, 2);
+            yield return CreateTestCase<nuint>((nuint)3, (nuint)13, 2);
             yield return CreateTestCase<IntWrapper>(new IntWrapper(3), new IntWrapper(13), 2);
             yield return CreateTestCase<DayOfWeek>(DayOfWeek.Wednesday, (DayOfWeek)13, 2);
         }
@@ -2456,8 +2521,10 @@ namespace Genumerics.Tests
         BigInteger = 2048,
         IntWrapper = 4096,
         DayOfWeek = 8192,
-        Integral = SByte | Byte | Int16 | UInt16 | Int32 | UInt32 | Int64 | UInt64 | BigInteger | IntWrapper | DayOfWeek,
-        Signed = SByte | Int16 | Int32 | Int64 | Floating | BigInteger | IntWrapper | DayOfWeek,
+        NativeInt = 0x4000,
+        NativeUInt = 0x8000,
+        Integral = SByte | Byte | Int16 | UInt16 | Int32 | UInt32 | Int64 | UInt64 | BigInteger | NativeInt | NativeUInt | IntWrapper | DayOfWeek,
+        Signed = SByte | Int16 | Int32 | Int64 | Floating | BigInteger | NativeInt | IntWrapper | DayOfWeek,
         All = Integral | Floating
     }
 

--- a/src/Genumerics.sln
+++ b/src/Genumerics.sln
@@ -9,6 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Genumerics.Tests", "Genumer
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B4FBA507-CD1E-40A3-BCBC-4AF9F0D2EAE1}"
 	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
+		..\LICENSE = ..\LICENSE
+		..\.github\workflows\netcore.yml = ..\.github\workflows\netcore.yml
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/Genumerics/DefaultNumericOperations.cs
+++ b/src/Genumerics/DefaultNumericOperations.cs
@@ -1367,10 +1367,10 @@ namespace Genumerics
         public sbyte ToSByte(BigInteger value) => (sbyte)value;
 
         /// <inheritdoc />
-        public sbyte ToSByte(nint value) => (sbyte)value;
+        public sbyte ToSByte(nint value) => checked((sbyte)value);
 
         /// <inheritdoc />
-        public sbyte ToSByte(nuint value) => (sbyte)value;
+        public sbyte ToSByte(nuint value) => checked((sbyte)value);
         #endregion
 
         #region ToByte
@@ -1411,10 +1411,10 @@ namespace Genumerics
         public byte ToByte(BigInteger value) => (byte)value;
 
         /// <inheritdoc />
-        public byte ToByte(nint value) => (byte)value;
+        public byte ToByte(nint value) => checked((byte)value);
 
         /// <inheritdoc />
-        public byte ToByte(nuint value) => (byte)value;
+        public byte ToByte(nuint value) => checked((byte)value);
         #endregion
 
         #region ToInt16
@@ -1455,10 +1455,10 @@ namespace Genumerics
         public short ToInt16(BigInteger value) => (short)value;
 
         /// <inheritdoc />
-        public short ToInt16(nint value) => (short)value;
+        public short ToInt16(nint value) => checked((short)value);
 
         /// <inheritdoc />
-        public short ToInt16(nuint value) => (short)value;
+        public short ToInt16(nuint value) => checked((short)value);
         #endregion
 
         #region ToUInt16
@@ -1499,10 +1499,10 @@ namespace Genumerics
         public ushort ToUInt16(BigInteger value) => (ushort)value;
 
         /// <inheritdoc />
-        public ushort ToUInt16(nint value) => (ushort)value;
+        public ushort ToUInt16(nint value) => checked((ushort)value);
 
         /// <inheritdoc />
-        public ushort ToUInt16(nuint value) => (ushort)value;
+        public ushort ToUInt16(nuint value) => checked((ushort)value);
         #endregion
 
         #region ToInt32
@@ -1543,10 +1543,10 @@ namespace Genumerics
         public int ToInt32(BigInteger value) => (int)value;
 
         /// <inheritdoc />
-        public int ToInt32(nint value) => (int)value;
+        public int ToInt32(nint value) => checked((int)value);
 
         /// <inheritdoc />
-        public int ToInt32(nuint value) => (int)value;
+        public int ToInt32(nuint value) => checked((int)value);
         #endregion
 
         #region ToUInt32
@@ -1587,10 +1587,10 @@ namespace Genumerics
         public uint ToUInt32(BigInteger value) => (uint)value;
 
         /// <inheritdoc />
-        public uint ToUInt32(nint value) => (uint)value;
+        public uint ToUInt32(nint value) => checked((uint)value);
 
         /// <inheritdoc />
-        public uint ToUInt32(nuint value) => (uint)value;
+        public uint ToUInt32(nuint value) => checked((uint)value);
         #endregion
 
         #region ToInt64
@@ -1634,7 +1634,7 @@ namespace Genumerics
         public long ToInt64(nint value) => (long)value;
 
         /// <inheritdoc />
-        public long ToInt64(nuint value) => (long)value;
+        public long ToInt64(nuint value) => checked((long)value);
         #endregion
 
         #region ToUInt64
@@ -1675,7 +1675,7 @@ namespace Genumerics
         public ulong ToUInt64(BigInteger value) => (ulong)value;
 
         /// <inheritdoc />
-        public ulong ToUInt64(nint value) => (ulong)value;
+        public ulong ToUInt64(nint value) => checked((ulong)value);
 
         /// <inheritdoc />
         public ulong ToUInt64(nuint value) => (ulong)value;
@@ -1719,10 +1719,10 @@ namespace Genumerics
         public float ToSingle(BigInteger value) => (float)value;
 
         /// <inheritdoc />
-        public float ToSingle(nint value) => (float)value;
+        public float ToSingle(nint value) => value;
 
         /// <inheritdoc />
-        public float ToSingle(nuint value) => (float)value;
+        public float ToSingle(nuint value) => value;
         #endregion
 
         #region ToDouble
@@ -1763,10 +1763,10 @@ namespace Genumerics
         public double ToDouble(BigInteger value) => (double)value;
 
         /// <inheritdoc />
-        public double ToDouble(nint value) => (double)value;
+        public double ToDouble(nint value) => value;
 
         /// <inheritdoc />
-        public double ToDouble(nuint value) => (double)value;
+        public double ToDouble(nuint value) => value;
         #endregion
 
         #region ToDecimal

--- a/src/Genumerics/DefaultNumericOperations.cs
+++ b/src/Genumerics/DefaultNumericOperations.cs
@@ -1125,13 +1125,21 @@ namespace Genumerics
         nint INumericOperations<nint>.Parse(string value, NumberStyles? style, IFormatProvider? provider)
         {
             var styleValue = style ?? NumberStyles.Integer;
-            return IntPtr.Size == 4 ? int.Parse(value, styleValue, provider) : (nint)long.Parse(value, styleValue, provider);
+            return IntPtr.Size switch {
+                4 => int.Parse(value, styleValue, provider),
+                8 => (nint)long.Parse(value, styleValue, provider),
+                _ => throw new NotSupportedException(),
+            };
         }
 
         nuint INumericOperations<nuint>.Parse(string value, NumberStyles? style, IFormatProvider? provider)
         {
             var styleValue = style ?? NumberStyles.Integer;
-            return UIntPtr.Size == 4 ? uint.Parse(value, styleValue, provider) : (nuint)ulong.Parse(value, styleValue, provider);
+            return UIntPtr.Size switch {
+                4 => uint.Parse(value, styleValue, provider),
+                8 => (nuint)ulong.Parse(value, styleValue, provider),
+                _ => throw new NotSupportedException(),
+            };
         }
         #endregion
 
@@ -1173,10 +1181,40 @@ namespace Genumerics
         public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out BigInteger result) => BigInteger.TryParse(value, style ?? NumberStyles.Integer, provider, out result);
 
         /// <inheritdoc />
-        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nint result) => throw new NotSupportedException();
+        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nint result)
+        {
+            bool success;
+            switch (IntPtr.Size) {
+            case 4:
+                success = this.TryParse(value, style, provider, out int i32);
+                result = i32;
+                return success;
+            case 8:
+                success = this.TryParse(value, style, provider, out long i64);
+                result = (nint)i64;
+                return success;
+            default:
+                throw new NotSupportedException();
+            }
+        }
 
         /// <inheritdoc />
-        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nuint result) => throw new NotSupportedException();
+        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nuint result)
+        {
+            bool success;
+            switch (UIntPtr.Size) {
+            case 4:
+                success = this.TryParse(value, style, provider, out uint u32);
+                result = u32;
+                return success;
+            case 8:
+                success = this.TryParse(value, style, provider, out ulong u64);
+                result = (nuint)u64;
+                return success;
+            default:
+                throw new NotSupportedException();
+            }
+        }
         #endregion
 
 #if SPAN
@@ -1205,9 +1243,25 @@ namespace Genumerics
 
         BigInteger INumericOperations<BigInteger>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => BigInteger.Parse(value, style ?? NumberStyles.Integer, provider);
 
-        nint INumericOperations<nint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+        nint INumericOperations<nint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider)
+        {
+            var styleValue = style ?? NumberStyles.Integer;
+            return IntPtr.Size switch {
+                4 => int.Parse(value, styleValue, provider),
+                8 => (nint)long.Parse(value, styleValue, provider),
+                _ => throw new NotSupportedException(),
+            };
+        }
 
-        nuint INumericOperations<nuint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+        nuint INumericOperations<nuint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider)
+        {
+            var styleValue = style ?? NumberStyles.Integer;
+            return UIntPtr.Size switch {
+                4 => uint.Parse(value, styleValue, provider),
+                8 => (nuint)ulong.Parse(value, styleValue, provider),
+                _ => throw new NotSupportedException(),
+            };
+        }
         #endregion
 
         #region TryParse
@@ -1248,10 +1302,40 @@ namespace Genumerics
         public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out BigInteger result) => BigInteger.TryParse(value, style ?? NumberStyles.Integer, provider, out result);
 
         /// <inheritdoc />
-        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nint result) => throw new NotSupportedException();
+        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nint result)
+        {
+            bool success;
+            switch (IntPtr.Size) {
+            case 4:
+                success = this.TryParse(value, style, provider, out int i32);
+                result = i32;
+                return success;
+            case 8:
+                success = this.TryParse(value, style, provider, out long i64);
+                result = (nint)i64;
+                return success;
+            default:
+                throw new NotSupportedException();
+            }
+        }
 
         /// <inheritdoc />
-        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nuint result) => throw new NotSupportedException();
+        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nuint result)
+        {
+            bool success;
+            switch (UIntPtr.Size) {
+            case 4:
+                success = this.TryParse(value, style, provider, out uint u32);
+                result = u32;
+                return success;
+            case 8:
+                success = this.TryParse(value, style, provider, out ulong u64);
+                result = (nuint)u64;
+                return success;
+            default:
+                throw new NotSupportedException();
+            }
+        }
         #endregion
 
         #region TryFormat
@@ -1292,10 +1376,12 @@ namespace Genumerics
         public bool TryFormat(BigInteger value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => value.TryFormat(destination, out charsWritten, format, provider);
 
         /// <inheritdoc />
-        public bool TryFormat(nint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => throw new NotSupportedException();
+        public bool TryFormat(nint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+            => ((long)value).TryFormat(destination, out charsWritten, format, provider);
 
         /// <inheritdoc />
-        public bool TryFormat(nuint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => throw new NotSupportedException();
+        public bool TryFormat(nuint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+            => ((ulong)value).TryFormat(destination, out charsWritten, format, provider);
         #endregion
 #endif
 

--- a/src/Genumerics/DefaultNumericOperations.cs
+++ b/src/Genumerics/DefaultNumericOperations.cs
@@ -33,7 +33,15 @@ namespace Genumerics
     /// Defines all the default numeric operations.
     /// </summary>
     [CLSCompliant(false)]
-    public readonly struct DefaultNumericOperations : INumericOperations<sbyte>, INumericOperations<byte>, INumericOperations<short>, INumericOperations<ushort>, INumericOperations<int>, INumericOperations<uint>, INumericOperations<long>, INumericOperations<ulong>, INumericOperations<float>, INumericOperations<double>, INumericOperations<decimal>, INumericOperations<BigInteger>
+    public readonly struct DefaultNumericOperations :
+        INumericOperations<sbyte>, INumericOperations<byte>,
+        INumericOperations<short>, INumericOperations<ushort>,
+        INumericOperations<int>, INumericOperations<uint>,
+        INumericOperations<long>, INumericOperations<ulong>,
+        INumericOperations<nint>, INumericOperations<nuint>,
+        INumericOperations<float>, INumericOperations<double>,
+        INumericOperations<decimal>,
+        INumericOperations<BigInteger>
     {
         #region Zero
         sbyte INumericOperations<sbyte>.Zero => 0;
@@ -51,6 +59,10 @@ namespace Genumerics
         long INumericOperations<long>.Zero => 0L;
 
         ulong INumericOperations<ulong>.Zero => 0UL;
+
+        nint INumericOperations<nint>.Zero => 0;
+
+        nuint INumericOperations<nuint>.Zero => 0;
 
         float INumericOperations<float>.Zero => 0F;
 
@@ -78,6 +90,10 @@ namespace Genumerics
 
         ulong INumericOperations<ulong>.One => 1UL;
 
+        nint INumericOperations<nint>.One => 1;
+
+        nuint INumericOperations<nuint>.One => 1;
+
         float INumericOperations<float>.One => 1F;
 
         double INumericOperations<double>.One => 1D;
@@ -103,6 +119,10 @@ namespace Genumerics
         long INumericOperations<long>.MinusOne => -1L;
 
         ulong INumericOperations<ulong>.MinusOne => throw new NotSupportedException("unsigned integral type cannot be negative");
+
+        nint INumericOperations<nint>.MinusOne => -1;
+
+        nuint INumericOperations<nuint>.MinusOne => throw new NotSupportedException("unsigned integral type cannot be negative");
 
         float INumericOperations<float>.MinusOne => -1F;
 
@@ -137,6 +157,10 @@ namespace Genumerics
         decimal INumericOperations<decimal>.MaxValue => decimal.MaxValue;
 
         BigInteger INumericOperations<BigInteger>.MaxValue => throw new NotSupportedException("there is no MaxValue for BigInteger");
+
+        nint INumericOperations<nint>.MaxValue => IntPtr.Size == 4 ? int.MaxValue : unchecked((nint)long.MaxValue);
+
+        nuint INumericOperations<nuint>.MaxValue => unchecked((nuint)0 - 1);
         #endregion
 
         #region MinValue
@@ -163,6 +187,10 @@ namespace Genumerics
         decimal INumericOperations<decimal>.MinValue => decimal.MinValue;
 
         BigInteger INumericOperations<BigInteger>.MinValue => throw new NotSupportedException("there is no MinValue for BigInteger");
+
+        nint INumericOperations<nint>.MinValue => IntPtr.Size == 4 ? int.MinValue : unchecked((nint)long.MinValue);
+
+        nuint INumericOperations<nuint>.MinValue => 0;
         #endregion
 
         #region TypeCode
@@ -189,6 +217,10 @@ namespace Genumerics
         TypeCode INumericOperations<decimal>.TypeCode => TypeCode.Decimal;
 
         TypeCode INumericOperations<BigInteger>.TypeCode => TypeCode.Object;
+
+        TypeCode INumericOperations<nint>.TypeCode => TypeCode.Object;
+
+        TypeCode INumericOperations<nuint>.TypeCode => TypeCode.Object;
         #endregion
 
         #region Equals
@@ -227,6 +259,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool Equals(BigInteger left, BigInteger right) => left == right;
+
+        /// <inheritdoc />
+        public bool Equals(nint left, nint right) => left == right;
+        /// <inheritdoc />
+        public bool Equals(nuint left, nuint right) => left == right;
         #endregion
 
         #region NotEquals
@@ -265,6 +302,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool NotEquals(BigInteger left, BigInteger right) => left != right;
+
+        /// <inheritdoc />
+        public bool NotEquals(nint left, nint right) => left != right;
+        /// <inheritdoc />
+        public bool NotEquals(nuint left, nuint right) => left != right;
         #endregion
 
         #region LessThan
@@ -303,6 +345,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool LessThan(BigInteger left, BigInteger right) => left < right;
+
+        /// <inheritdoc />
+        public bool LessThan(nint left, nint right) => left < right;
+        /// <inheritdoc />
+        public bool LessThan(nuint left, nuint right) => left < right;
         #endregion
 
         #region LessThanOrEqual
@@ -341,6 +388,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool LessThanOrEqual(BigInteger left, BigInteger right) => left <= right;
+
+        /// <inheritdoc />
+        public bool LessThanOrEqual(nint left, nint right) => left <= right;
+        /// <inheritdoc />
+        public bool LessThanOrEqual(nuint left, nuint right) => left <= right;
         #endregion
 
         #region GreaterThan
@@ -379,6 +431,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool GreaterThan(BigInteger left, BigInteger right) => left > right;
+
+        /// <inheritdoc />
+        public bool GreaterThan(nint left, nint right) => left > right;
+        /// <inheritdoc />
+        public bool GreaterThan(nuint left, nuint right) => left > right;
         #endregion
 
         #region GreaterThanOrEqual
@@ -417,6 +474,11 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool GreaterThanOrEqual(BigInteger left, BigInteger right) => left >= right;
+
+        /// <inheritdoc />
+        public bool GreaterThanOrEqual(nint left, nint right) => left >= right;
+        /// <inheritdoc />
+        public bool GreaterThanOrEqual(nuint left, nuint right) => left >= right;
         #endregion
 
         #region Add
@@ -455,6 +517,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Add(BigInteger left, BigInteger right) => left + right;
+
+        /// <inheritdoc />
+        public nint Add(nint left, nint right) => left + right;
+
+        /// <inheritdoc />
+        public nuint Add(nuint left, nuint right) => left + right;
         #endregion
 
         #region Subtract
@@ -493,6 +561,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Subtract(BigInteger left, BigInteger right) => left - right;
+
+        /// <inheritdoc />
+        public nint Subtract(nint left, nint right) => left - right;
+
+        /// <inheritdoc />
+        public nuint Subtract(nuint left, nuint right) => left - right;
         #endregion
 
         #region Multiply
@@ -531,6 +605,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Multiply(BigInteger left, BigInteger right) => left * right;
+
+        /// <inheritdoc />
+        public nint Multiply(nint left, nint right) => left * right;
+
+        /// <inheritdoc />
+        public nuint Multiply(nuint left, nuint right) => left * right;
         #endregion
 
         #region Divide
@@ -569,6 +649,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Divide(BigInteger dividend, BigInteger divisor) => dividend / divisor;
+
+        /// <inheritdoc />
+        public nint Divide(nint left, nint right) => left / right;
+
+        /// <inheritdoc />
+        public nuint Divide(nuint left, nuint right) => left / right;
         #endregion
 
         #region Remainder
@@ -607,6 +693,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Remainder(BigInteger dividend, BigInteger divisor) => dividend % divisor;
+
+        /// <inheritdoc />
+        public nint Remainder(nint dividend, nint divisor) => dividend % divisor;
+
+        /// <inheritdoc />
+        public nuint Remainder(nuint dividend, nuint divisor) => dividend % divisor;
         #endregion
 
         #region DivRem
@@ -681,6 +773,20 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger DivRem(BigInteger dividend, BigInteger divisor, out BigInteger remainder) => BigInteger.DivRem(dividend, divisor, out remainder);
+
+        /// <inheritdoc />
+        public nint DivRem(nint dividend, nint divisor, out nint remainder)
+        {
+            remainder = dividend % divisor;
+            return dividend / divisor;
+        }
+
+        /// <inheritdoc />
+        public nuint DivRem(nuint dividend, nuint divisor, out nuint remainder)
+        {
+            remainder = dividend % divisor;
+            return dividend / divisor;
+        }
         #endregion
 
         #region Negate
@@ -719,6 +825,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Negate(BigInteger value) => -value;
+
+        /// <inheritdoc />
+        public nint Negate(nint value) => -value;
+
+        /// <inheritdoc />
+        public nuint Negate(nuint value) => throw new NotSupportedException("cannot negate unsigned integral type");
         #endregion
 
         #region BitwiseAnd
@@ -757,6 +869,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger BitwiseAnd(BigInteger left, BigInteger right) => left & right;
+
+        /// <inheritdoc />
+        public nint BitwiseAnd(nint left, nint right) => left & right;
+
+        /// <inheritdoc />
+        public nuint BitwiseAnd(nuint left, nuint right) => left & right;
         #endregion
 
         #region BitwiseOr
@@ -795,6 +913,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger BitwiseOr(BigInteger left, BigInteger right) => left | right;
+
+        /// <inheritdoc />
+        public nint BitwiseOr(nint left, nint right) => left | right;
+
+        /// <inheritdoc />
+        public nuint BitwiseOr(nuint left, nuint right) => left | right;
         #endregion
 
         #region Xor
@@ -833,6 +957,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Xor(BigInteger left, BigInteger right) => left ^ right;
+
+        /// <inheritdoc />
+        public nint Xor(nint left, nint right) => left ^ right;
+
+        /// <inheritdoc />
+        public nuint Xor(nuint left, nuint right) => left ^ right;
         #endregion
 
         #region OnesComplement
@@ -871,6 +1001,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger OnesComplement(BigInteger value) => ~value;
+
+        /// <inheritdoc />
+        public nint OnesComplement(nint value) => ~value;
+
+        /// <inheritdoc />
+        public nuint OnesComplement(nuint value) => ~value;
         #endregion
 
         #region LeftShift
@@ -909,6 +1045,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger LeftShift(BigInteger value, int shift) => value << shift;
+
+        /// <inheritdoc />
+        public nint LeftShift(nint value, int shift) => value << shift;
+
+        /// <inheritdoc />
+        public nuint LeftShift(nuint value, int shift) => value << shift;
         #endregion
 
         #region RightShift
@@ -947,6 +1089,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger RightShift(BigInteger value, int shift) => value >> shift;
+
+        /// <inheritdoc />
+        public nint RightShift(nint value, int shift) => value >> shift;
+
+        /// <inheritdoc />
+        public nuint RightShift(nuint value, int shift) => value >> shift;
         #endregion
 
         #region Parse
@@ -973,6 +1121,10 @@ namespace Genumerics
         decimal INumericOperations<decimal>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => decimal.Parse(value, style ?? NumberStyles.Number, provider);
 
         BigInteger INumericOperations<BigInteger>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => BigInteger.Parse(value, style ?? NumberStyles.Integer, provider);
+
+        nint INumericOperations<nint>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+
+        nuint INumericOperations<nuint>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
         #endregion
 
         #region TryParse
@@ -1011,6 +1163,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out BigInteger result) => BigInteger.TryParse(value, style ?? NumberStyles.Integer, provider, out result);
+
+        /// <inheritdoc />
+        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nint result) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryParse(string value, NumberStyles? style, IFormatProvider? provider, out nuint result) => throw new NotSupportedException();
         #endregion
 
 #if SPAN
@@ -1038,6 +1196,10 @@ namespace Genumerics
         decimal INumericOperations<decimal>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => decimal.Parse(value, style ?? NumberStyles.Number, provider);
 
         BigInteger INumericOperations<BigInteger>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => BigInteger.Parse(value, style ?? NumberStyles.Integer, provider);
+
+        nint INumericOperations<nint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+
+        nuint INumericOperations<nuint>.Parse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
         #endregion
 
         #region TryParse
@@ -1076,6 +1238,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out BigInteger result) => BigInteger.TryParse(value, style ?? NumberStyles.Integer, provider, out result);
+
+        /// <inheritdoc />
+        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nint result) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryParse(ReadOnlySpan<char> value, NumberStyles? style, IFormatProvider? provider, out nuint result) => throw new NotSupportedException();
         #endregion
 
         #region TryFormat
@@ -1114,6 +1282,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool TryFormat(BigInteger value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => value.TryFormat(destination, out charsWritten, format, provider);
+
+        /// <inheritdoc />
+        public bool TryFormat(nint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryFormat(nuint value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => throw new NotSupportedException();
         #endregion
 #endif
 
@@ -1141,6 +1315,10 @@ namespace Genumerics
         decimal INumericOperations<decimal>.Convert<TFrom>(TFrom value) => Number.GetOperations<TFrom>()?.ToDecimal(value) ?? Convert.ToDecimal(value);
 
         BigInteger INumericOperations<BigInteger>.Convert<TFrom>(TFrom value) => value != null ? Number.GetOperationsInternal<TFrom>().ToBigInteger(value) : default;
+
+        nint INumericOperations<nint>.Convert<TFrom>(TFrom value) => throw new NotSupportedException();
+
+        nuint INumericOperations<nuint>.Convert<TFrom>(TFrom value) => throw new NotSupportedException();
         #endregion
 
         #region ToSByte
@@ -1179,6 +1357,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public sbyte ToSByte(BigInteger value) => (sbyte)value;
+
+        /// <inheritdoc />
+        public sbyte ToSByte(nint value) => (sbyte)value;
+
+        /// <inheritdoc />
+        public sbyte ToSByte(nuint value) => (sbyte)value;
         #endregion
 
         #region ToByte
@@ -1217,6 +1401,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public byte ToByte(BigInteger value) => (byte)value;
+
+        /// <inheritdoc />
+        public byte ToByte(nint value) => (byte)value;
+
+        /// <inheritdoc />
+        public byte ToByte(nuint value) => (byte)value;
         #endregion
 
         #region ToInt16
@@ -1255,6 +1445,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public short ToInt16(BigInteger value) => (short)value;
+
+        /// <inheritdoc />
+        public short ToInt16(nint value) => (short)value;
+
+        /// <inheritdoc />
+        public short ToInt16(nuint value) => (short)value;
         #endregion
 
         #region ToUInt16
@@ -1293,6 +1489,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public ushort ToUInt16(BigInteger value) => (ushort)value;
+
+        /// <inheritdoc />
+        public ushort ToUInt16(nint value) => (ushort)value;
+
+        /// <inheritdoc />
+        public ushort ToUInt16(nuint value) => (ushort)value;
         #endregion
 
         #region ToInt32
@@ -1331,6 +1533,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public int ToInt32(BigInteger value) => (int)value;
+
+        /// <inheritdoc />
+        public int ToInt32(nint value) => (int)value;
+
+        /// <inheritdoc />
+        public int ToInt32(nuint value) => (int)value;
         #endregion
 
         #region ToUInt32
@@ -1369,6 +1577,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public uint ToUInt32(BigInteger value) => (uint)value;
+
+        /// <inheritdoc />
+        public uint ToUInt32(nint value) => (uint)value;
+
+        /// <inheritdoc />
+        public uint ToUInt32(nuint value) => (uint)value;
         #endregion
 
         #region ToInt64
@@ -1407,6 +1621,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public long ToInt64(BigInteger value) => (long)value;
+
+        /// <inheritdoc />
+        public long ToInt64(nint value) => (long)value;
+
+        /// <inheritdoc />
+        public long ToInt64(nuint value) => (long)value;
         #endregion
 
         #region ToUInt64
@@ -1445,6 +1665,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public ulong ToUInt64(BigInteger value) => (ulong)value;
+
+        /// <inheritdoc />
+        public ulong ToUInt64(nint value) => (ulong)value;
+
+        /// <inheritdoc />
+        public ulong ToUInt64(nuint value) => (ulong)value;
         #endregion
 
         #region ToSingle
@@ -1483,6 +1709,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public float ToSingle(BigInteger value) => (float)value;
+
+        /// <inheritdoc />
+        public float ToSingle(nint value) => (float)value;
+
+        /// <inheritdoc />
+        public float ToSingle(nuint value) => (float)value;
         #endregion
 
         #region ToDouble
@@ -1521,6 +1753,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public double ToDouble(BigInteger value) => (double)value;
+
+        /// <inheritdoc />
+        public double ToDouble(nint value) => (double)value;
+
+        /// <inheritdoc />
+        public double ToDouble(nuint value) => (double)value;
         #endregion
 
         #region ToDecimal
@@ -1559,6 +1797,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public decimal ToDecimal(BigInteger value) => (decimal)value;
+
+        /// <inheritdoc />
+        public decimal ToDecimal(nint value) => (decimal)value;
+
+        /// <inheritdoc />
+        public decimal ToDecimal(nuint value) => (decimal)value;
         #endregion
 
         #region ToBigInteger
@@ -1597,6 +1841,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger ToBigInteger(BigInteger value) => value;
+
+        /// <inheritdoc />
+        public BigInteger ToBigInteger(nint value) => new (value);
+
+        /// <inheritdoc />
+        public BigInteger ToBigInteger(nuint value) => new (value);
         #endregion
 
         #region Round
@@ -1642,6 +1892,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Round(BigInteger value, int digits, MidpointRounding mode) => value;
+
+        /// <inheritdoc />
+        public nint Round(nint value, int digits, MidpointRounding mode) => value;
+
+        /// <inheritdoc />
+        public nuint Round(nuint value, int digits, MidpointRounding mode) => value;
         #endregion
 
         #region Floor
@@ -1687,6 +1943,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Floor(BigInteger value) => value;
+
+        /// <inheritdoc />
+        public nint Floor(nint value) => value;
+
+        /// <inheritdoc />
+        public nuint Floor(nuint value) => value;
         #endregion
 
         #region Ceiling
@@ -1732,6 +1994,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Ceiling(BigInteger value) => value;
+
+        /// <inheritdoc />
+        public nint Ceiling(nint value) => value;
+
+        /// <inheritdoc />
+        public nuint Ceiling(nuint value) => value;
         #endregion
 
         #region Truncate
@@ -1777,6 +2045,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Truncate(BigInteger value) => value;
+
+        /// <inheritdoc />
+        public nint Truncate(nint value) => value;
+
+        /// <inheritdoc />
+        public nuint Truncate(nuint value) => value;
         #endregion
 
         #region Compare
@@ -1815,6 +2089,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public int Compare(BigInteger left, BigInteger right) => left.CompareTo(right);
+
+        /// <inheritdoc />
+        public int Compare(nint left, nint right) => ((long)left).CompareTo((long)right);
+
+        /// <inheritdoc />
+        public int Compare(nuint left, nuint right) => ((ulong)left).CompareTo((ulong)right);
         #endregion
 
         #region Abs
@@ -1853,6 +2133,18 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Abs(BigInteger value) => BigInteger.Abs(value);
+
+        /// <inheritdoc />
+        public nint Abs(nint value)
+        {
+            nint neg = -value;
+            if (neg >= 0) return neg;
+            if (value == neg) throw new OverflowException();
+            return value;
+        }
+
+        /// <inheritdoc />
+        public nuint Abs(nuint value) => value;
         #endregion
 
         #region Max
@@ -1891,6 +2183,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Max(BigInteger left, BigInteger right) => BigInteger.Max(left, right);
+
+        /// <inheritdoc />
+        public nint Max(nint left, nint right) => left > right ? left : right;
+
+        /// <inheritdoc />
+        public nuint Max(nuint left, nuint right) => left > right ? left : right;
         #endregion
 
         #region Min
@@ -1929,6 +2227,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public BigInteger Min(BigInteger left, BigInteger right) => BigInteger.Min(left, right);
+
+        /// <inheritdoc />
+        public nint Min(nint left, nint right) => left < right ? left : right;
+
+        /// <inheritdoc />
+        public nuint Min(nuint left, nuint right) => left < right ? left : right;
         #endregion
 
         #region Sign
@@ -1967,6 +2271,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public int Sign(BigInteger value) => value.Sign;
+
+        /// <inheritdoc />
+        public int Sign(nint value) => Math.Sign(value);
+
+        /// <inheritdoc />
+        public int Sign(nuint value) => value == 0 ? 0 : 1;
         #endregion
 
         #region ToString
@@ -2005,6 +2315,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public string ToString(BigInteger value, string? format, IFormatProvider? provider) => value.ToString(format, provider);
+
+        /// <inheritdoc />
+        public string ToString(nint value, string? format, IFormatProvider? provider) => ((long)value).ToString(format, provider);
+
+        /// <inheritdoc />
+        public string ToString(nuint value, string? format, IFormatProvider? provider) => ((ulong)value).ToString(format, provider);
         #endregion
 
         #region IsEven
@@ -2043,6 +2359,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool IsEven(BigInteger value) => value.IsEven;
+
+        /// <inheritdoc />
+        public bool IsEven(nint value) => (value % 2) == 0;
+
+        /// <inheritdoc />
+        public bool IsEven(nuint value) => (value % 2U) == 0U;
         #endregion
 
         #region IsOdd
@@ -2081,6 +2403,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool IsOdd(BigInteger value) => !value.IsEven;
+
+        /// <inheritdoc />
+        public bool IsOdd(nint value) => (value % 2) == 1;
+
+        /// <inheritdoc />
+        public bool IsOdd(nuint value) => (value % 2U) == 1U;
         #endregion
 
         #region IsPowerOfTwo
@@ -2119,6 +2447,12 @@ namespace Genumerics
 
         /// <inheritdoc />
         public bool IsPowerOfTwo(BigInteger value) => value.IsPowerOfTwo;
+
+        /// <inheritdoc />
+        public bool IsPowerOfTwo(nint value) => (value & (value - 1)) == 0;
+
+        /// <inheritdoc />
+        public bool IsPowerOfTwo(nuint value) => (value & (value - 1U)) == 0U;
         #endregion
 
         #region Clamp
@@ -2264,6 +2598,46 @@ namespace Genumerics
 
             return value;
 #endif
+        }
+
+        /// <inheritdoc />
+        public nint Clamp(nint value, nint min, nint max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            if (value < min)
+            {
+                return min;
+            }
+            else if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+
+        /// <inheritdoc />
+        public nuint Clamp(nuint value, nuint min, nuint max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            if (value < min)
+            {
+                return min;
+            }
+            else if (value > max)
+            {
+                return max;
+            }
+
+            return value;
         }
 
         /// <inheritdoc />

--- a/src/Genumerics/DefaultNumericOperations.cs
+++ b/src/Genumerics/DefaultNumericOperations.cs
@@ -1122,9 +1122,17 @@ namespace Genumerics
 
         BigInteger INumericOperations<BigInteger>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => BigInteger.Parse(value, style ?? NumberStyles.Integer, provider);
 
-        nint INumericOperations<nint>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+        nint INumericOperations<nint>.Parse(string value, NumberStyles? style, IFormatProvider? provider)
+        {
+            var styleValue = style ?? NumberStyles.Integer;
+            return IntPtr.Size == 4 ? int.Parse(value, styleValue, provider) : (nint)long.Parse(value, styleValue, provider);
+        }
 
-        nuint INumericOperations<nuint>.Parse(string value, NumberStyles? style, IFormatProvider? provider) => throw new NotSupportedException();
+        nuint INumericOperations<nuint>.Parse(string value, NumberStyles? style, IFormatProvider? provider)
+        {
+            var styleValue = style ?? NumberStyles.Integer;
+            return UIntPtr.Size == 4 ? uint.Parse(value, styleValue, provider) : (nuint)ulong.Parse(value, styleValue, provider);
+        }
         #endregion
 
         #region TryParse

--- a/src/Genumerics/Genumerics.csproj
+++ b/src/Genumerics/Genumerics.csproj
@@ -25,7 +25,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>genumerics.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Genumerics/Number.cs
+++ b/src/Genumerics/Number.cs
@@ -196,6 +196,14 @@ namespace Genumerics
             {
                 return (T)(object)BigInteger.Zero;
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(nint)0;
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(nuint)0;
+            }
             else
             {
                 return GetOperationsInternal<T>().Zero;
@@ -259,6 +267,14 @@ namespace Genumerics
             {
                 return (T)(object)BigInteger.One;
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(nint)1;
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(nuint)1;
+            }
             else
             {
                 return GetOperationsInternal<T>().One;
@@ -307,6 +323,10 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)BigInteger.MinusOne;
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(nint)(-1);
             }
             else
             {
@@ -401,6 +421,14 @@ namespace Genumerics
             {
                 return ((BigInteger)(object)left!) == ((BigInteger)(object)right!);
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) == ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) == ((nuint)(object)right!);
+            }
             else
             {
                 return GetOperationsInternal<T>().Equals(left, right);
@@ -465,6 +493,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return ((BigInteger)(object)left!) != ((BigInteger)(object)right!);
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) != ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) != ((nuint)(object)right!);
             }
             else
             {
@@ -531,6 +567,14 @@ namespace Genumerics
             {
                 return ((BigInteger)(object)left!) < ((BigInteger)(object)right!);
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) < ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) < ((nuint)(object)right!);
+            }
             else
             {
                 return GetOperationsInternal<T>().LessThan(left, right);
@@ -595,6 +639,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return ((BigInteger)(object)left!) <= ((BigInteger)(object)right!);
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) <= ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) <= ((nuint)(object)right!);
             }
             else
             {
@@ -661,6 +713,14 @@ namespace Genumerics
             {
                 return ((BigInteger)(object)left!) > ((BigInteger)(object)right!);
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) > ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) > ((nuint)(object)right!);
+            }
             else
             {
                 return GetOperationsInternal<T>().GreaterThan(left, right);
@@ -725,6 +785,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return ((BigInteger)(object)left!) >= ((BigInteger)(object)right!);
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return ((nint)(object)left!) >= ((nint)(object)right!);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return ((nuint)(object)left!) >= ((nuint)(object)right!);
             }
             else
             {
@@ -791,6 +859,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)left!) + ((BigInteger)(object)right!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) + ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) + ((nuint)(object)right!));
+            }
             else
             {
                 return GetOperationsInternal<T>().Add(left, right);
@@ -856,6 +932,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)left!) - ((BigInteger)(object)right!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) - ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) - ((nuint)(object)right!));
+            }
             else
             {
                 return GetOperationsInternal<T>().Subtract(left, right);
@@ -920,6 +1004,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)(((BigInteger)(object)left!) * ((BigInteger)(object)right!));
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) * ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) * ((nuint)(object)right!));
             }
             else
             {
@@ -987,6 +1079,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)dividend!) / ((BigInteger)(object)divisor!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)dividend!) / ((nint)(object)divisor!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)dividend!) / ((nuint)(object)divisor!));
+            }
             else
             {
                 return GetOperationsInternal<T>().Divide(dividend, divisor);
@@ -1053,6 +1153,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)dividend!) % ((BigInteger)(object)divisor!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)dividend!) % ((nint)(object)divisor!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)dividend!) % ((nuint)(object)divisor!));
+            }
             else
             {
                 return GetOperationsInternal<T>().Remainder(dividend, divisor);
@@ -1114,6 +1222,10 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)-(BigInteger)(object)value!;
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)-(nint)(object)value!;
             }
             else
             {
@@ -1190,6 +1302,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)left!) & ((BigInteger)(object)right!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) & ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) & ((nuint)(object)right!));
+            }
             else
             {
                 return GetOperationsInternal<T>().BitwiseAnd(left, right);
@@ -1244,6 +1364,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)(((BigInteger)(object)left!) | ((BigInteger)(object)right!));
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) | ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) | ((nuint)(object)right!));
             }
             else
             {
@@ -1300,6 +1428,14 @@ namespace Genumerics
             {
                 return (T)(object)(((BigInteger)(object)left!) ^ ((BigInteger)(object)right!));
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)(((nint)(object)left!) ^ ((nint)(object)right!));
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)(((nuint)(object)left!) ^ ((nuint)(object)right!));
+            }
             else
             {
                 return GetOperationsInternal<T>().Xor(left, right);
@@ -1353,6 +1489,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)~(BigInteger)(object)value!;
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)~(nint)(object)value!;
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)~(nuint)(object)value!;
             }
             else
             {
@@ -1409,6 +1553,14 @@ namespace Genumerics
             {
                 return (T)(object)((BigInteger)(object)value! << shift);
             }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)((nint)(object)value! << shift);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)((nuint)(object)value! << shift);
+            }
             else
             {
                 return GetOperationsInternal<T>().LeftShift(value, shift);
@@ -1463,6 +1615,14 @@ namespace Genumerics
             else if (typeof(T) == typeof(BigInteger))
             {
                 return (T)(object)((BigInteger)(object)value! >> shift);
+            }
+            else if (typeof(T) == typeof(nint))
+            {
+                return (T)(object)((nint)(object)value! >> shift);
+            }
+            else if (typeof(T) == typeof(nuint))
+            {
+                return (T)(object)((nuint)(object)value! >> shift);
             }
             else
             {


### PR DESCRIPTION
Implementation of generic algebra for new C# 9 `nint` and `nuint` types.

Also changed target frameworks: dropped EOLed .NET Core 2.0 and 3.0, and added .NET Core 3.1 LTS (technically, this might require major version bump according to SemVer).